### PR TITLE
Serial baud rate setting

### DIFF
--- a/src/emonhub_listener.py
+++ b/src/emonhub_listener.py
@@ -228,7 +228,7 @@ class EmonHubListener(object):
         """
         pass
 
-    def _open_serial_port(self, com_port):
+    def _open_serial_port(self, com_port, com_baud):
         """Open serial port
 
         com_port (string): path to COM port
@@ -237,8 +237,13 @@ class EmonHubListener(object):
         
         self._log.debug('Opening serial port: %s', com_port)
         
+        if not int(com_baud) in [75, 110, 300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200]:
+            self._log.debug("Invalid 'com_baud': " + str(com_baud) + " | Default of 9600 used")
+            com_baud = 9600
+
         try:
-            s = serial.Serial(com_port, 9600, timeout=0)
+            s = serial.Serial(com_port, com_baud, timeout=0)
+            self._log.info("Opened serial port : " + str(com_baud) + " bits/s")
         except serial.SerialException as e:
             self._log.error(e)
             raise EmonHubListenerInitError('Could not open COM port %s' %
@@ -275,7 +280,7 @@ Monitors the serial port for data
 
 class EmonHubSerialListener(EmonHubListener):
 
-    def __init__(self, com_port):
+    def __init__(self, com_port, com_baud=9600):
         """Initialize listener
 
         com_port (string): path to COM port
@@ -286,7 +291,7 @@ class EmonHubSerialListener(EmonHubListener):
         super(EmonHubSerialListener, self).__init__()
 
         # Open serial port
-        self._ser = self._open_serial_port(com_port)
+        self._ser = self._open_serial_port(com_port, com_baud)
         
         # Initialize RX buffer
         self._rx_buf = ''
@@ -338,7 +343,7 @@ Monitors the serial port for data from "Jee" type device
 
 class EmonHubJeeListener(EmonHubSerialListener):
 
-    def __init__(self, com_port):
+    def __init__(self, com_port, com_baud=9600):
         """Initialize listener
 
         com_port (string): path to COM port
@@ -346,7 +351,7 @@ class EmonHubJeeListener(EmonHubSerialListener):
         """
         
         # Initialization
-        super(EmonHubJeeListener, self).__init__(com_port)
+        super(EmonHubJeeListener, self).__init__(com_port, com_baud)
 
         # Initialize settings
         self._settings = {'baseid': '', 'frequency': '', 'sgroup': '',
@@ -531,7 +536,7 @@ and repeats on RF link the frames received through a socket
 
 class EmonHubJeeListenerRepeater(EmonHubJeeListener):
 
-    def __init__(self, com_port, port_nb):
+    def __init__(self, com_port, port_nb, com_baud=9600):
         """Initialize listener
 
         com_port (string): path to COM port
@@ -540,7 +545,7 @@ class EmonHubJeeListenerRepeater(EmonHubJeeListener):
         """
         
         # Initialization
-        super(EmonHubJeeListenerRepeater, self).__init__(com_port)
+        super(EmonHubJeeListenerRepeater, self).__init__(com_port, com_baud)
 
         # Open socket
         self._socket = self._open_socket(port_nb)


### PR DESCRIPTION
Added an optional setting for baud rate. if omitted the default value hardcoded in the respective listener will be used and if the passed value (setting or default) is not on the "common values" list then it will default to 9600.
