### PR TITLE
Default 'runtime settings' and routines

### DIFF
--- a/src/emonhub_dispatcher.py
+++ b/src/emonhub_dispatcher.py
@@ -33,8 +33,7 @@ class EmonHubDispatcher(object):
         # Initialize logger
         self._log = logging.getLogger("EmonHub")
 
-        # Initialise settings
-        self._defaults = {'pause': 0, 'interval': 0, 'maxItemsPerPost': 1}
+        # Initialize variables
         self._settings = {}
         self.name = ''
         
@@ -58,18 +57,10 @@ class EmonHubDispatcher(object):
             'pause' = anything else, commented out or omitted then dispatcher is fully operational
         
         """
-
-        for key, setting in self._defaults.iteritems():
-            if not key in kwargs.keys():
-                setting = self._defaults[key]
-            else:
-                setting = kwargs[key]
-            if key in self._settings and self._settings[key] == setting:
-                pass
-            else:
-                self._settings[key] = setting
-                self._log.debug("Setting " + self.name + " " + key + ": " + str(setting))
-
+        # check if 'pause' has been removed or commented out
+        if not 'pause' in kwargs and 'pause' in self._settings:
+            self._settings['pause'] = False
+       
         for key, value in kwargs.iteritems():
             # Strip trailing slash
             if key == 'url':
@@ -120,11 +111,12 @@ class EmonHubDispatcher(object):
         # Buffer management
         # If data buffer not empty, send a set of values
         if self.buffer.hasItems():
-            max_items = int(self._settings['maxItemsPerPost'])
-            if max_items > 250:
-                max_items = 250
-            elif max_items <= 0:
-                return
+            if 'maxItemsPerPost' in self._settings.keys():
+                max_items = int(self._settings['maxItemsPerPost'])
+                if max_items > 250:
+                    max_items = 250
+            else:
+                max_items = 1
 
             databuffer = self.buffer.retrieveItems(max_items)
             retrievedlength = len(databuffer)

--- a/src/emonhub_listener.py
+++ b/src/emonhub_listener.py
@@ -49,39 +49,38 @@ class EmonHubListener(object):
         """
         pass
 
-    def _process_frame(self, t, f):
+    def _process_frame(self, timestamp, frame):
         """Process a frame of data
 
         f (string): 'NodeID val1 val2 ...'
 
         This function splits the string into numbers and check its validity.
 
-        'NodeID val1 val2 ...' is the generic data format. If the source uses
+        'NodeID val1 val2 ...' is the generic data format. If the source uses 
         a different format, override this method.
-
+        
         Return data as a list: [NodeID, val1, val2]
 
         """
 
         # Log data
-        self._log.info(" NEW FRAME : " + str(t) + " " + f)
+        self._log.info(" NEW FRAME : " + str(timestamp) + " " + frame)
         
         # Get an array out of the space separated string
-        received = f.strip().split(' ')
+        frame = frame.strip().split(' ')
 
         # Validate frame
-        if not self._validate_frame(received):
+        if not self._validate_frame(frame):
             self._log.debug('Discard RX Frame "Failed validation"')
             return
 
-        decoded = self._decode_frame(received)
+        frame = self._decode_frame(frame)
 
-        if decoded:
-            self._log.debug("Timestamp : " + str(t))
-            self._log.debug("     Node : " + str(decoded[0]))
-            self._log.debug("   Values : " + str(decoded[1:]))
-            processed = [t]
-            processed += decoded
+        if frame:
+            self._log.debug("Timestamp : " + str(timestamp))
+            self._log.debug("     Node : " + str(frame[0]))
+            self._log.debug("   Values : " + str(frame[1:]))
+            frame = [timestamp] + frame
         else:
             return
 
@@ -89,8 +88,8 @@ class EmonHubListener(object):
         if 'pause' in self._settings and self._settings['pause'] in \
                 ['o', 'O', 'out', 'Out', 'OUT', 't', 'T', 'true', 'True', 'TRUE']:
             return
-
-        return processed
+        
+        return frame
 
     def _validate_frame(self, received):
         """Validate a frame of data
@@ -118,7 +117,7 @@ class EmonHubListener(object):
         # If it passes all the checks return True
         return True
 
-    def _decode_frame(self, received):
+    def _decode_frame(self, data):
         """Decodes a frame of data
 
         Performs decoding of data types
@@ -127,8 +126,8 @@ class EmonHubListener(object):
 
         """
 
-        node = received[0]
-        data = received[1:]
+        node = data[0]
+        data = data[1:]
         decoded = []
 
         # check if node is listed and has individual datacodes for each value

--- a/src/emonhub_listener.py
+++ b/src/emonhub_listener.py
@@ -35,7 +35,11 @@ class EmonHubListener(object):
 
         # Initialise settings
         self.name = ''
-        self._settings = {'defaultdatacode': ''}
+        self._defaults = {'pause': 0, 'interval': 0, 'defaultdatacode': 0}
+        self._settings = {}
+
+        # Initialize interval timer's "started at" timestamp
+        self._interval_timestamp = 0
         
     def close(self):
         """Close socket."""
@@ -207,26 +211,17 @@ class EmonHubListener(object):
             'pause' = anything else, commented out or omitted then dispatcher is fully operational
         
         """
-        key = 'defaultdatacode'
-        value = ''
-        try:
-            kwargs[key]
-        except:
-            value = False
-        else:
-            value = kwargs[key]
-            if not ehc.check_datacode(value):
-                value = False
-        finally:
-            if value != self._settings[key]:
-                self._settings[key] = value
-                self._log.debug("Setting " + self.name + " default datacode : %s", self._settings[key])
 
-        # check if 'pause' has been removed or commented out
-        if not 'pause' in kwargs and 'pause' in self._settings:
-            self._settings['pause'] = False
-        elif 'pause' in kwargs:
-            self._settings['pause'] = kwargs['pause']
+        for key, setting in self._defaults.iteritems():
+            if not key in kwargs.keys():
+                setting = self._defaults[key]
+            else:
+                setting = kwargs[key]
+            if key in self._settings and self._settings[key] == setting:
+                pass
+            else:
+                self._settings[key] = setting
+                self._log.debug("Setting " + self.name + " " + key + ": " + str(setting))
 
     def run(self):
         """Placeholder for background tasks. 
@@ -363,11 +358,8 @@ class EmonHubJeeListener(EmonHubSerialListener):
         super(EmonHubJeeListener, self).__init__(com_port, com_baud)
 
         # Initialize settings
-        self._settings = {'baseid': '', 'frequency': '', 'sgroup': '',
-                          'sendtimeinterval': '', 'defaultdatacode': ''}
-        
-        # Initialize time update timestamp
-        self._time_update_timestamp = 0
+        self._defaults.update({'pause': 0, 'interval': 0, 'defaultdatacode': 'h'})
+        self._settings.update({'baseid': '', 'frequency': '', 'sgroup': ''})
 
     def _validate_frame(self, received):
         """Validate a frame of data
@@ -407,9 +399,6 @@ class EmonHubJeeListener(EmonHubSerialListener):
         
         """
 
-        # include kwargs from parent
-        super(EmonHubJeeListener, self).set(**kwargs)
-        
         for key, value in kwargs.iteritems():
             # If radio setting modified, transmit on serial link
             if key in ['baseid', 'frequency', 'sgroup']:
@@ -426,10 +415,9 @@ class EmonHubJeeListener(EmonHubSerialListener):
                     self._ser.write(string)
                     # Wait a sec between two settings
                     time.sleep(1)
-            elif key == 'sendtimeinterval':
-                if value != self._settings[key]:
-                    self._log.info("Setting " + self.name + " send time interval : %s", value)
-                    self._settings[key] = value
+
+        # include kwargs from parent
+        super(EmonHubJeeListener, self).set(**kwargs)
 
     def run(self):
         """Actions that need to be done on a regular basis. 
@@ -441,11 +429,11 @@ class EmonHubJeeListener(EmonHubSerialListener):
         now = time.time()
 
         # Broadcast time to synchronize emonGLCD
-        interval = int(self._settings['sendtimeinterval'])
+        interval = int(self._settings['interval'])
         if interval:  # A value of 0 means don't do anything
-            if now - self._time_update_timestamp > interval:
+            if now - self._interval_timestamp > interval:
                 self._send_time()
-                self._time_update_timestamp = now
+                self._interval_timestamp = now
     
     def _send_time(self):
         """Send time over radio link to synchronize emonGLCD
@@ -460,7 +448,7 @@ class EmonHubJeeListener(EmonHubSerialListener):
 
         now = datetime.datetime.now()
 
-        self._log.debug("Broadcasting time: %d:%d" % (now.hour, now.minute))
+        self._log.debug(self.name + " broadcasting time: %02d:%02d" % (now.hour, now.minute))
 
         self._ser.write("00,%02d,%02d,00,s" % (now.hour, now.minute))
 


### PR DESCRIPTION
Default 'runtime settings' now has a consistent mechanism to load default values as provided in any listener or dispatcher code or to be overridden by emonhub.conf settings, see commits for more details
Added comments to decoder functions and redduced variable creation by reusing redundant variables.
