### PR TITLE
Creation & Deletion of Dispatchers and Listeners

### DIFF
--- a/src/emonhub_dispatcher.py
+++ b/src/emonhub_dispatcher.py
@@ -200,3 +200,13 @@ class EmonHubEmoncmsDispatcher(EmonHubDispatcher):
                 return True
             else:
                 self._log.warning("Send failure: wanted 'ok' but got "+reply)
+
+"""class EmonHubDispatcherInitError
+
+Raise this when init fails.
+
+"""
+
+
+class EmonHubDispatcherInitError(Exception):
+    pass


### PR DESCRIPTION
Listeners and Dispatchers are only created if 'type' is in settings, therefore if listener or dispatcher not to be created, only the 'type' needs to be commented out to omit rather than every line. this has been extended to tell emonHub to delete the listener or dispatcher if the type is missing.
Fixed an issue with delete that would crash emonHub due to the list changing during iteration by adding .keys
The delete has also been moved ahead of the creation routines to handle single instance issues eg Pi serial port, if a seriallistener is renamed it will be gracefully closed before the new one is created using the same serial port, previously it tried to create a second serial port conn, failed, aborted and moved on to delete the original listener.
Dispatcher creation & deletion routine changed to match listener with exceptin handling (dispatcher class).
