### PR TITLE
Dispatcher default settings

### DIFF
--- a/conf/emonhub.conf
+++ b/conf/emonhub.conf
@@ -14,9 +14,9 @@
 
 # All lines beginning with a '#' are comments and can be safely removed.
 
-####################
-# emonHub settings #
-####################
+#######################################################################
+#######################    emonHub  settings    #######################
+#######################################################################
 [hub]
 
 # log file path
@@ -26,38 +26,25 @@ logfile = /var/log/emonhub.log
 # see here : http://docs.python.org/2/library/logging.html
 loglevel = DEBUG
 
-###############
-# Dispatchers #
-###############
+
+#######################################################################
+#######################       Dispatchers       #######################
+#######################################################################
 [dispatchers]
 
-# This dispatcher sends data to a emoncms.org account
-[[emoncms_org]]
-    type = EmonHubEmoncmsDispatcher
-    [[[init_settings]]]
-    [[[runtime_settings]]]
-        url = http://emoncms.org/
-        apikey = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
-# This dispatcher sends data to a locally installed emonCMS
-[[emoncms_local]]
+# This dispatcher sends data to emonCMS
+[[emonCMS]]
     type = EmonHubEmoncmsDispatcher
     [[[init_settings]]]
     [[[runtime_settings]]]
         url = http://localhost/emoncms
-        apikey = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        apikey = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-#############
-# Listeners #
-#############
+
+#######################################################################
+#######################        Listeners        #######################
+#######################################################################
 [listeners]
-
-# This listener gets data from a socket
-[[Socket]]
-    type = EmonHubSocketListener
-    [[[init_settings]]]
-        port_nb = 50011
-    [[[runtime_settings]]]
 
 # This listener manages the RFM2Pi module
 [[RFM2Pi]]
@@ -69,9 +56,10 @@ loglevel = DEBUG
         frequency = 433
         baseid = 15
 
-#########
-# Nodes #
-#########
+
+#######################################################################
+#######################          Nodes          #######################
+#######################################################################
 [nodes]
 
 # List of nodes by node ID


### PR DESCRIPTION
Dispatcher defaults added so that if no "url" specified in emoncms
dispatcher it will default to emoncms.org. localhost address is set
ready for local install or just delete or edit url string for
emoncms.org account. If apikey is not set (ie 4 or more x's or omitted)
dispatcher will not send (but it will still acumulate data in buffer
until apikey changed. emonCMS defaults to a max of 100 items per post
which can be overridden.
emonhub.conf has been reduced some more and now only has a single
"emonCMS" dispatcher and a single "RFM2Pi" listener.
