### PR TITLE
Filtering rfm69 packets

### DIFF
--- a/src/emonhub_listener.py
+++ b/src/emonhub_listener.py
@@ -398,6 +398,10 @@ class EmonHubJeeListener(EmonHubSerialListener):
             self._log.info("Ignoring frame consisting of SOH character")
             return False
 
+        if received[0] == '?'and str(received[-1])[0]=='(' and str(received[-1])[-1]==')':
+            self._log.info("Discard RX frame 'unreliable content' : RSSI " + str(received[-1]))
+            return False
+
         # Strip 'OK' and extract RSSI if packet is from RFM69 type Jee Device
         if received[0]=='OK' and str(received[-1])[0]=='(' and str(received[-1])[-1]==')':
             self.rssi = int(received[-1][1:-1])


### PR DESCRIPTION
Discard any packets starting with '?' and ending with an 'RSSI' as
unreliable content.
