### PR TITLE
Naming strategy "Type"

### DIFF
--- a/conf/emonhub.conf
+++ b/conf/emonhub.conf
@@ -29,9 +29,9 @@ loglevel = WARNING
 #######################################################################
 [reporters]
 
-# This dispatcher sends data to emonCMS
+# This reporter sends data to emonCMS
 [[emonCMS]]
-    type = EmonHubEmoncmsReporter
+    Type = EmonHubEmoncmsReporter
     [[[init_settings]]]
     [[[runtimesettings]]]
         url = http://localhost/emoncms
@@ -45,7 +45,7 @@ loglevel = WARNING
 
 # This interfacer manages the RFM2Pi module
 [[RFM2Pi]]
-    type = EmonHubJeeInterfacer
+    Type = EmonHubJeeInterfacer
     [[[init_settings]]]
         com_port = /dev/ttyAMA0
     [[[runtimesettings]]]

--- a/src/emonhub.py
+++ b/src/emonhub.py
@@ -136,11 +136,11 @@ class EmonHub(object):
             if self._reporters[name].init_settings != settings['reporters'][name]['init_settings']:
                 if self._reporters[name].buffer._data_buffer:
                     self.temp_buffer[name]= self._reporters[name].buffer._data_buffer
-            # Or if reporter is still in the settings and has a 'type' just move on to the next one
-            # (This provides an ability to delete & rebuild by commenting 'type' in conf)
-            elif name in settings['reporters'] and 'type' in settings['reporters'][name]:
+            # Or if reporter is still in the settings and has a 'Type' just move on to the next one
+            # (This provides an ability to delete & rebuild by commenting 'Type' in conf)
+            elif name in settings['reporters'] and 'Type' in settings['reporters'][name]:
                 continue
-            # Delete reporters if setting changed or name is unlisted or type is missing
+            # Delete reporters if setting changed or name is unlisted or Type is missing
             self._log.info("Deleting reporter '%s'", name)
             self._reporters[name].stop = True
             del(self._reporters[name])
@@ -148,13 +148,13 @@ class EmonHub(object):
             # If reporter does not exist, create it
             if name not in self._reporters:
                 try:
-                    if not 'type' in R:
+                    if not 'Type' in R:
                         continue
-                    self._log.info("Creating " + R['type'] + " '%s' ", name)
+                    self._log.info("Creating " + R['Type'] + " '%s' ", name)
                     # Create the queue for this reporter
                     self._queue[name] = Queue.Queue(0)
-                    # This gets the class from the 'type' string
-                    reporter = getattr(ehr, R['type'])(name, self._queue[name], **R['init_settings'])
+                    # This gets the class from the 'Type' string
+                    reporter = getattr(ehr, R['Type'])(name, self._queue[name], **R['init_settings'])
                     reporter.init_settings = R['init_settings']
                     # If a memory buffer back-up exists copy it over and remove the back-up
                     if name in self.temp_buffer:
@@ -174,9 +174,9 @@ class EmonHub(object):
             # check init_settings against the file copy, if they are different pass for deletion
             if self._interfacers[name].init_settings != settings['interfacers'][name]['init_settings']:
                 pass
-            # Or if Interfacer is still in the settings and has a 'type' just move on to the next one
-            # (This provides an ability to delete & rebuild by commenting 'type' in conf)
-            elif name in settings['interfacers'] and 'type' in settings['interfacers'][name]:
+            # Or if Interfacer is still in the settings and has a 'Type' just move on to the next one
+            # (This provides an ability to delete & rebuild by commenting 'Type' in conf)
+            elif name in settings['interfacers'] and 'Type' in settings['interfacers'][name]:
                 continue
             self._interfacers[name].close()
             self._log.info("Deleting interfacer '%s' ", name)
@@ -185,11 +185,11 @@ class EmonHub(object):
             # If interfacer does not exist, create it
             if name not in self._interfacers:
                 try:
-                    if not 'type' in I:
+                    if not 'Type' in I:
                         continue
-                    self._log.info("Creating " + I['type'] + " '%s' ", name)
-                    # This gets the class from the 'type' string
-                    interfacer = getattr(ehi, I['type'])(**I['init_settings'])
+                    self._log.info("Creating " + I['Type'] + " '%s' ", name)
+                    # This gets the class from the 'Type' string
+                    interfacer = getattr(ehi, I['Type'])(**I['init_settings'])
                     interfacer.init_settings = I['init_settings']
                 except ehi.EmonHubInterfacerInitError as e:
                     # If interfacer can't be created, log error and skip to next

--- a/src/emonhub_reporter.py
+++ b/src/emonhub_reporter.py
@@ -133,7 +133,7 @@ class EmonHubReporter(threading.Thread):
                 self.add(frame)
             # Don't loop to fast
             time.sleep(0.1)
-            # Action dispatcher tasks
+            # Action reporter tasks
             self.action()
 
     def action(self):

--- a/src/emonhub_setup.py
+++ b/src/emonhub_setup.py
@@ -20,17 +20,17 @@ dictionary with the following keys:
 
         'hub': a dictionary containing the hub settings
         'interfacers': a dictionary containing the interfacers
-        'dispatchers': a dictionary containing the dispatchers
+        'reporters': a dictionary containing the reporters
 
         The hub settings are:
         'loglevel': the logging level
         
-        interfacers and dispatchers are dictionaries with the following keys:
-        'type': class name
+        interfacers and reporters are dictionaries with the following keys:
+        'Type': class name
         'init_settings': dictionary with initialization settings
         'runtimesettings': dictionary with runtime settings
         Initialization and runtime settings depend on the interfacer and
-        dispatcher type.
+        reporter type.
 
 The run() method is supposed to be run regularly by the instantiater, to
 perform regular communication tasks.


### PR DESCRIPTION
Renamed "type =" to "Type = " to match the types having to be written in
camel case. plus couple more naming corrections
