### PR TITLE
Fix settings update checking interval.

### DIFF
--- a/src/emonhub_setup.py
+++ b/src/emonhub_setup.py
@@ -114,11 +114,12 @@ class EmonHubFileSetup(EmonHubSetup):
         
         # Check settings only once per second
         now = time.time()
-        if now - self._settings_update_timestamp < 0:
+        if now < self._settings_update_timestamp:
             return
-        # Update timestamp
-        self._settings_update_timestamp = now
-        
+
+        # Update timestamp of when settings should next be checked:
+        self._settings_update_timestamp = now + 1
+
         # Backup settings
         settings = dict(self.settings)
         


### PR DESCRIPTION
_settings_update_timestamp is used to be the timestamp when settings should next be checked by, to allow either checking on the retry interval in case of failure, or no more than once per second if successful.

Note that prior to this change the Python process was consuming around 25% of CPU on a Raspberry Pi B+, whereas it is reduced to <10% afterwards.

(I wonder whether the common model of using SIGHUP to signal that the config should be re-read would be better, but I haven't had chance to look a how that would fit into the broader emon architecture and for now this at least stops my Pi getting too warm :-)).
